### PR TITLE
Change regex version, due to error in "from locale import getlocale a…

### DIFF
--- a/envs/nanoscope_debarcode.yaml
+++ b/envs/nanoscope_debarcode.yaml
@@ -1,48 +1,56 @@
-name: nanoscope_debarcode
+name: nanoscope_debarcode2
 channels:
-  - defaults
-  - conda-forge
   - bioconda
+  - conda-forge
+  - defaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
-  - argparse=1.4.0=py36_0
-  - bzip2=1.0.8=h7f98852_4
-  - c-ares=1.18.1=h7f98852_0
-  - ca-certificates=2022.12.7=ha878542_0
-  - certifi=2016.9.26=py36_0
-  - contextlib2=21.6.0=pyhd8ed1ab_0
-  - glob2=0.7=py_0
+  - bzip2=1.0.8=hd590300_5
+  - c-ares=1.26.0=hd590300_0
+  - ca-certificates=2023.11.17=hbcca054_0
   - keyutils=1.6.1=h166bdaf_0
-  - krb5=1.19.3=h3790be6_0
+  - krb5=1.21.2=h659d440_0
   - ld_impl_linux-64=2.40=h41732ed_0
-  - libcurl=7.86.0=h7bff187_1
-  - libdeflate=1.13=h166bdaf_0
+  - levenshtein=0.24.0=py310hc6cd4ac_0
+  - libblas=3.9.0=21_linux64_openblas
+  - libcblas=3.9.0=21_linux64_openblas
+  - libcurl=8.5.0=hca28451_0
+  - libdeflate=1.18=h0b41bf4_0
   - libedit=3.1.20191231=he28a2e2_2
-  - libev=4.33=h516909a_1
+  - libev=4.33=hd590300_2
   - libffi=3.4.2=h7f98852_5
-  - libgcc-ng=12.2.0=h65d4601_19
-  - libgomp=12.2.0=h65d4601_19
-  - libnghttp2=1.47.0=hdcd2b5c_1
-  - libnsl=2.0.0=h7f98852_0
-  - libsqlite=3.40.0=h753d276_0
-  - libssh2=1.10.0=haa6b8db_3
-  - libstdcxx-ng=12.2.0=h46fd767_19
-  - libzlib=1.2.13=h166bdaf_4
-  - ncurses=6.3=h27087fc_1
-  - openssl=1.1.1t=h0b41bf4_0
-  - pip=21.2.4=pyhd8ed1ab_0
-  - pysam=0.20.0=py36h50b03f4_0
-  - python=3.6.15=hb7a2778_0_cpython
-  - python-levenshtein=0.12.2=py36h8f6f2f9_0
-  - python_abi=3.6=2_cp36m
-  - pyyaml=5.4.1=py36h8f6f2f9_1
-  - readline=8.1.2=h0f457ee_0
-  - regex=2016.06.24=py36_1
-  - setuptools=49.6.0=py36h5fab9bb_3
-  - sqlite=3.40.0=h4ff8645_0
-  - tk=8.6.12=h27826a3_0
-  - wheel=0.34.2=py36_0
+  - libgcc-ng=13.2.0=h807b86a_4
+  - libgfortran-ng=13.2.0=h69a702a_4
+  - libgfortran5=13.2.0=ha4646dd_4
+  - libgomp=13.2.0=h807b86a_4
+  - liblapack=3.9.0=21_linux64_openblas
+  - libnghttp2=1.58.0=h47da74e_1
+  - libnsl=2.0.1=hd590300_0
+  - libopenblas=0.3.26=pthreads_h413a1c8_0
+  - libsqlite=3.44.2=h2797004_0
+  - libssh2=1.11.0=h0841786_0
+  - libstdcxx-ng=13.2.0=h7e041cc_4
+  - libuuid=2.38.1=h0b41bf4_0
+  - libxcrypt=4.4.36=hd590300_1
+  - libzlib=1.2.13=hd590300_5
+  - ncurses=6.4=h59595ed_2
+  - numpy=1.26.3=py310hb13e2d6_0
+  - openssl=3.2.1=hd590300_0
+  - pip=23.3.2=pyhd8ed1ab_0
+  - pysam=0.22.0=py310h41dec4a_0
+  - python=3.10.13=hd12c33a_1_cpython
+  - python-levenshtein=0.24.0=pyhd8ed1ab_0
+  - python_abi=3.10=4_cp310
+  - pyyaml=6.0.1=py310h2372a71_1
+  - rapidfuzz=3.6.1=py310hc6cd4ac_0
+  - readline=8.2=h8228510_1
+  - regex=2023.12.25=py310h2372a71_0
+  - setuptools=69.0.3=pyhd8ed1ab_0
+  - tk=8.6.13=noxft_h4845f30_101
+  - tzdata=2023d=h0c530f3_0
+  - wheel=0.42.0=pyhd8ed1ab_0
   - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
-  - zlib=1.2.13=h166bdaf_4
+  - zlib=1.2.13=hd590300_5
+  - zstd=1.5.5=hfc55251_0


### PR DESCRIPTION
This is patch to update environment of nanoscope_debarcode rule. On dardel, python3.6 causes problem when importin regex, this solves it. 

Python version change for debarcode rule from 3.6 -> 3.10